### PR TITLE
docs: add SECURITY.md with a responsible-disclosure process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+FuXi runs shell commands, stores provider credentials under `~/.fuxi/`, and
+self-updates over the network — security reports are welcome and appreciated.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities **privately** through GitHub's
+[security advisories](https://github.com/fuxicodex/Fuxi/security/advisories/new)
+("Report a vulnerability") on this repository. Do not open a public issue for
+security concerns.
+
+Include:
+
+- FuXi version (`fuxi --version`) and how it was installed,
+- operating system and shell,
+- a minimal reproduction or proof-of-concept,
+- the impact you believe it has.
+
+## What to expect
+
+Reports are reviewed on a best-effort basis; you will receive an initial
+response within a few days and follow-up updates as the report progresses.
+Please give maintainers a reasonable window before public disclosure.
+
+Thank you for helping keep FuXi users safe.


### PR DESCRIPTION
FuXi executes shell commands and stores provider credentials locally, so it needs a defined private disclosure path. This adds a SECURITY.md pointing reporters at GitHub's private security advisories instead of public issues.