### PR TITLE
docs: add CONTRIBUTING.md and a bug-report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Report a reproducible problem with FuXi
+title: ''
+labels: ''
+assignees: ''
+---
+
+**FuXi version** (`fuxi --version`):
+
+**OS / shell / terminal emulator:**
+
+**Provider** (Anthropic / OpenAI-compatible / Bedrock / Vertex / Gemini / other):
+
+**What happened?** (expected vs. actual)
+
+**Minimal reproduction steps**
+
+1.
+2.
+3.
+
+**Anything else?** (config snippets, error output — redact API keys)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to FuXi
+
+FuXi's source is proprietary, but this repository — the documentation, release
+installers, and issue tracker — is open to contributions.
+
+## Bug reports
+
+Open an issue using the **Bug report** template. The most useful reports include:
+
+- `fuxi --version` output,
+- operating system, shell, and terminal emulator,
+- the provider in use (Anthropic / OpenAI-compatible / Bedrock / Vertex / Gemini),
+- expected vs. actual behavior,
+- a minimal reproduction.
+
+## Documentation fixes and improvements
+
+Pull requests for the README (English and 简体中文), typo fixes, clarifications,
+and new documentation sections are welcome. Please keep the two languages in
+lockstep: if you change a section, update both `README.md` and
+`README.zh-CN.md`.
+
+## Pull requests
+
+- Keep PRs scoped to one change.
+- Describe what changed and why in the PR description.
+- A maintainer will review; response times are best-effort.
+
+Thank you!


### PR DESCRIPTION
Bug reports currently arrive unstructured; the template asks for version, OS/shell/terminal, provider, and a minimal repro — the fields maintainers need first. CONTRIBUTING.md also notes the EN/ZH lockstep convention.