### PR TITLE
docs: list NO_UPDATE_NOTIFIER in the env table (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Key environment variables:
 | `ANTHROPIC_MODEL` | Model name for the Anthropic provider |
 | `FUXI_THINKING_MODE` / `FUXI_THINKING_EFFORT` | `auto\|enabled\|disabled` / `low\|medium\|high\|max` |
 | `FUXI_CONFIG_DIR` | Override the config directory (default `~/.fuxi`) |
+| `NO_UPDATE_NOTIFIER` | Set to `1` to suppress the background update-check notice (same as `--no-update-notifier`) |
 | `FUXI_TEMPERATURE` / `FUXI_TOP_P` / `FUXI_SEED` | Sampling controls |
 
 Run `fuxi --help` for the full environment-variable reference, including bridge/

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -259,6 +259,7 @@ fuxi update 2.203.0    # 指定版本
 | `ANTHROPIC_MODEL` | Anthropic 提供商使用的模型名 |
 | `FUXI_THINKING_MODE` / `FUXI_THINKING_EFFORT` | `auto\|enabled\|disabled` / `low\|medium\|high\|max` |
 | `FUXI_CONFIG_DIR` | 覆盖配置目录（默认 `~/.fuxi`） |
+| `NO_UPDATE_NOTIFIER` | 设为 `1` 时关闭后台更新检查提示（等同 `--no-update-notifier`） |
 | `FUXI_TEMPERATURE` / `FUXI_TOP_P` / `FUXI_SEED` | 采样控制参数 |
 
 完整的环境变量参考（包括 bridge/remote-control、沙箱限制、MCP 资源上限


### PR DESCRIPTION
The Updating section documents `--no-update-notifier` / `NO_UPDATE_NOTIFIER=1` in prose, but the key environment variables table omits it. Adds the row to both languages so the two references agree.